### PR TITLE
Clean up code

### DIFF
--- a/includes/activate.php
+++ b/includes/activate.php
@@ -25,8 +25,8 @@ function activate() {
 	do_action( Core\HOOK_PREFIX . 'before_activate_process' );
 
 	// Do the checks for WooCommerce and Subscriptions both being active.
-	check_active_woo();
-	check_active_woo_subs();
+	check_active( Helpers\maybe_woo_activated() );
+	check_active( Helpers\maybe_woo_subs_activated() );
 
 	// Include our action so that we may add to this later.
 	do_action( Core\HOOK_PREFIX . 'after_activate_process' );
@@ -45,13 +45,10 @@ function activate() {
  *
  * @return void
  */
-function check_active_woo() {
-
-	// Pull the function check.
-	$maybe_activate = Helpers\maybe_woo_activated();
+function check_active( $check ) {
 
 	// If we weren't false, we are OK.
-	if ( false !== $maybe_activate ) {
+	if ( $check ) {
 		return;
 	}
 
@@ -59,27 +56,10 @@ function check_active_woo() {
 	deactivate_plugins( Core\BASE );
 
 	// And display the notice.
-	wp_die( sprintf( __( 'Using the Installment Plans for WooCommerce Subscriptions plugin required that you have WooCommerce installed and activated. <a href="%s">Click here</a> to return to the plugins page.', 'installment-plans-for-woo-subs' ), admin_url( '/plugins.php' ) ) );
-}
-
-/**
- * Handle checking if WooCommerce is present and activated.
- *
- * @return void
- */
-function check_active_woo_subs() {
-
-	// Pull the function check.
-	$maybe_activate = Helpers\maybe_woo_subs_activated();
-
-	// If we weren't false, we are OK.
-	if ( false !== $maybe_activate ) {
-		return;
-	}
-
-	// Deactivate the plugin.
-	deactivate_plugins( Core\BASE );
-
-	// And display the notice.
-	wp_die( sprintf( __( 'Using the Installment Plans for WooCommerce Subscriptions plugin required that you have WooCommerce Subscriptions installed and activated. <a href="%s">Click here</a> to return to the plugins page.', 'installment-plans-for-woo-subs' ), admin_url( '/plugins.php' ) ) );
+	wp_die( wp_kses_post( sprintf(
+		/* translators: %1$s: start of link tag, %2$s: end of link tag */
+		__( 'Using the Installment Plans for WooCommerce Subscriptions plugin requires that you have WooCommerce installed and activated. %1$Return to the plugins page%2$s.', 'installment-plans-for-woo-subs' ),
+		'<a href="' . admin_url( '/plugins.php' ) . '">',
+		'</a>'
+	) ) );
 }

--- a/includes/activate.php
+++ b/includes/activate.php
@@ -12,6 +12,8 @@ namespace Nexcess\InstallmentPlansWooSubs\Activate;
 use Nexcess\InstallmentPlansWooSubs as Core;
 use Nexcess\InstallmentPlansWooSubs\Helpers as Helpers;
 
+register_activation_hook( Core\FILE, __NAMESPACE__ . '\activate' );
+
 /**
  * Our inital setup function when activated.
  *
@@ -37,7 +39,6 @@ function activate() {
 	// seems to be required.
 	flush_rewrite_rules();
 }
-register_activation_hook( Core\FILE, __NAMESPACE__ . '\activate' );
 
 /**
  * Handle checking if WooCommerce is present and activated.

--- a/includes/deactivate.php
+++ b/includes/deactivate.php
@@ -11,6 +11,8 @@ namespace Nexcess\InstallmentPlansWooSubs\Deactivate;
 // Set our aliases.
 use Nexcess\InstallmentPlansWooSubs as Core;
 
+register_deactivation_hook( Core\FILE, __NAMESPACE__ . '\deactivate' );
+
 /**
  * Delete various options when deactivating the plugin.
  *
@@ -30,4 +32,3 @@ function deactivate() {
 	// And flush our rewrite rules.
 	flush_rewrite_rules();
 }
-register_deactivation_hook( Core\FILE, __NAMESPACE__ . '\deactivate' );

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -208,10 +208,10 @@ function maybe_subscriptions_endpoint_page( $in_query = false ) {
 function get_order_email_template_args( $order_id = 0, $order, $plaintext = false ) {
 
 	// Set the initial args from Subscriptions.
-	$template_args  = array(
+	$template_args = [
 		'base' => plugin_dir_path( \WC_Subscriptions::$plugin_file ) . 'templates/',
 		'file' => false !== $plaintext ? 'emails/plain/subscription-info.php' : 'emails/subscription-info.php',
-	);
+	];
 
 	// Now get the meta for our flag.
 	$installments   = get_post_meta( absint( $order_id ), '_order_has_installments', true );
@@ -220,10 +220,10 @@ function get_order_email_template_args( $order_id = 0, $order, $plaintext = fals
 	if ( ! empty( $installments ) && 'yes' === sanitize_text_field( $installments ) ) {
 
 		// Swap the values.
-		$template_args  = array(
+		$template_args = [
 			'base' => Core\TEMPLATES_PATH . '/',
 			'file' => false !== $plaintext ? 'emails/plain/installments-info.php' : 'emails/installments-info.php',
-		);
+		];
 	}
 
 	// Return it filtered.

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -54,23 +54,17 @@ function maybe_store_has_installments() {
 		// Call the global database.
 		global $wpdb;
 
-		// Set our table name.
-		$table_name = $wpdb->prefix . 'postmeta';
-
 		// Set up our query.
-		$query_args = $wpdb->prepare("
+		$query_run = $wpdb->get_results( $wpdb->prepare( "
 			SELECT   post_id
-			FROM     $table_name
-			WHERE    meta_key = '%s'
-			AND      meta_value = '%s'
+			FROM     $wpdb->postmeta
+			WHERE    meta_key = %s
+			AND      meta_value = %s
 			LIMIT    1
-		", esc_attr( '_is_installments' ), esc_attr( 'yes' ) );
-
-		// Process the query.
-		$query_run  = $wpdb->get_results( $query_args );
+		", esc_attr( '_is_installments' ), esc_attr( 'yes' ) ) );
 
 		// Bail without any reviews.
-		if ( empty( $query_run ) ) {
+		if ( empty( $query_run ) || is_wp_error( $query_run ) ) {
 			return false;
 		}
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -101,7 +101,7 @@ function maybe_order_has_installments( $order, $return_length = true ) {
 	}
 
 	// Attempt to get our items.
-	$fetch_order_items  = $order->get_items();
+	$fetch_order_items = $order->get_items();
 
 	// Bail if there are no items in the order.
 	if ( empty( $fetch_order_items ) ) {
@@ -120,7 +120,7 @@ function maybe_order_has_installments( $order, $return_length = true ) {
 		}
 
 		// Now check for the meta key.
-		$maybe_key  = get_post_meta( absint( $product_id ), '_is_installments', true );
+		$maybe_key = get_post_meta( absint( $product_id ), '_is_installments', true );
 
 		// If we have it, return true (and we're done).
 		if ( ! empty( $maybe_key ) && 'yes' === sanitize_text_field( $maybe_key ) ) {
@@ -214,7 +214,7 @@ function get_order_email_template_args( $order_id = 0, $order, $plaintext = fals
 	];
 
 	// Now get the meta for our flag.
-	$installments   = get_post_meta( absint( $order_id ), '_order_has_installments', true );
+	$installments = get_post_meta( absint( $order_id ), '_order_has_installments', true );
 
 	// If we have installments, use our own template setup.
 	if ( ! empty( $installments ) && 'yes' === sanitize_text_field( $installments ) ) {
@@ -240,7 +240,7 @@ function get_order_email_template_args( $order_id = 0, $order, $plaintext = fals
 function add_ordinal_suffix( $number = 1 ) {
 
 	// Set a default ordinal.
-	$default_ordinal    = $number . '<sup>th</sup>';
+	$default_ordinal = $number . '<sup>th</sup>';
 
 	// We have some we need to do mathletics to.
 	if ( ! in_array( ( $number % 100 ), array( 11, 12, 13 ) ) ) {

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -199,7 +199,7 @@ function maybe_subscriptions_endpoint_page( $in_query = false ) {
  *
  * @return array
  */
-function get_order_email_template_args( $order_id = 0, $order, $plaintext = false ) {
+function get_order_email_template_args( $order_id, $order, $plaintext = false ) {
 
 	// Set the initial args from Subscriptions.
 	$template_args = [

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -18,7 +18,7 @@ use Nexcess\InstallmentPlansWooSubs\Utilities as Utilities;
  * @return boolean
  */
 function maybe_woo_activated() {
-	return class_exists( 'woocommerce' ) ? true : false;
+	return class_exists( 'woocommerce' );
 }
 
 /**
@@ -27,7 +27,7 @@ function maybe_woo_activated() {
  * @return boolean
  */
 function maybe_woo_subs_activated() {
-	return function_exists( 'wcs_is_subscription' ) ? true : false;
+	return function_exists( 'wcs_is_subscription' );
 }
 
 /**
@@ -41,7 +41,7 @@ function maybe_store_has_installments() {
 	$ky = Core\TRANSIENT_PREFIX . 'has_installments';
 
 	// If we don't want the cache'd version, delete the transient first.
-	if ( defined( 'WP_DEBUG' ) && WP_DEBUG || ! empty( $purge ) ) {
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		delete_transient( $ky );
 	}
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -237,7 +237,7 @@ function add_ordinal_suffix( $number = 1 ) {
 	$default_ordinal = $number . '<sup>th</sup>';
 
 	// We have some we need to do mathletics to.
-	if ( ! in_array( ( $number % 100 ), array( 11, 12, 13 ) ) ) {
+	if ( ! in_array( ( $number % 100 ), [ 11, 12, 13 ], true ) ) {
 
 		// Set an empty string.
 		$ordinal_number = '';

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -72,7 +72,7 @@ function wcsip_array_insert_after( $needle = '', $haystack = array(), $new_key =
 	}
 
 	// Set our merged array.
-	$merged_array   = array();
+	$merged_array = [];
 
 	// Loop the haystack and find our key.
 	foreach ( $haystack as $haystack_key => $haystack_value ) {
@@ -105,9 +105,6 @@ function wcsip_get_user_installments( $user_id = 0, $return_count = false ) {
 		$user_id = get_current_user_id();
 	}
 
-	// Set an empty.
-	$subscriptions  = array();
-
 	// Attempt to fetch the IDs.
 	$fetch_sub_ids  = WCS_Customer_Store::instance()->get_users_subscription_ids( $user_id );
 
@@ -115,6 +112,9 @@ function wcsip_get_user_installments( $user_id = 0, $return_count = false ) {
 	if ( empty( $fetch_sub_ids ) ) {
 		return false;
 	}
+
+	// Set an empty array.
+	$subscriptions = [];
 
 	// Now loop the IDs and pull out each one.
 	foreach ( $fetch_sub_ids as $single_id ) {

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -25,24 +25,24 @@ function wcsip_get_email_content_args( $subscription, $order ) {
 	$get_single_count   = get_post_meta( $order->get_id(), '_order_installment_count', true );
 
 	// Set our single total and increment.
-	$set_single_increm  = Helpers\add_ordinal_suffix( $subscription->get_payment_count() );
-	$set_single_total   = wc_price( $subscription->get_total(), array( 'currency' => $subscription->get_currency() ) );
 	$set_single_count   = ! empty( $get_single_count ) ? $get_single_count : 0;
+	$set_single_increm = Helpers\add_ordinal_suffix( $subscription->get_payment_count() );
+	$set_single_total  = wc_price( $subscription->get_total(), [ 'currency' => $subscription->get_currency() ] );
 
 	// Calculate the total cost.
 	$calc_instalm_total = absint( $subscription->get_total() ) * absint( $set_single_count );
-	$set_instalm_total  = wc_price( $calc_instalm_total, array( 'currency' => $subscription->get_currency() ) );
+	$set_instalm_total  = wc_price( $calc_instalm_total, [ 'currency' => $subscription->get_currency() ] );
 
 	// Set an array for this.
-	$set_content_array  = array(
 		'payment-detail'   => sprintf( __( '%s payment of %s', 'installment-plans-for-woo-subs' ), $set_single_increm, $set_single_total ),
+	$set_content_array = [
 		'payment-counts'   => sprintf( _n( '%d total payment', '%d total payments', $set_single_count, 'installment-plans-for-woo-subs' ), $set_single_count ),
 		'payment-schedule' => sprintf( __( '%s per %s', 'installment-plans-for-woo-subs' ), $set_single_total, $subscription->get_billing_period() ),
 		'payment-totals'   => sprintf( __( '%s total', 'installment-plans-for-woo-subs' ), $set_instalm_total ),
 		'no-remaining'     => esc_html_x( 'no remaining payments', 'the payment made was the final one', 'installment-plans-for-woo-subs' ),
 		'single-count'     => $set_single_count,
 		'total-cost'       => $set_instalm_total,
-	);
+	];
 
 	// Return the content array.
 	return apply_filters( Core\HOOK_PREFIX . 'email_content_args', $set_content_array, $subscription, $order );

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -22,7 +22,7 @@ use Nexcess\InstallmentPlansWooSubs\Helpers as Helpers;
 function wcsip_get_email_content_args( $subscription, $order ) {
 
 	// Begin by handling all our various calculations and meta pulls.
-	$get_single_count   = get_post_meta( $order->get_id(), '_order_installment_count', true );
+	$get_single_count = get_post_meta( $order->get_id(), '_order_installment_count', true );
 
 	// Set our single total and increment.
 	$set_single_count   = ! empty( $get_single_count ) ? $get_single_count : 0;

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -34,10 +34,14 @@ function wcsip_get_email_content_args( $subscription, $order ) {
 	$set_instalm_total  = wc_price( $calc_instalm_total, [ 'currency' => $subscription->get_currency() ] );
 
 	// Set an array for this.
-		'payment-detail'   => sprintf( __( '%s payment of %s', 'installment-plans-for-woo-subs' ), $set_single_increm, $set_single_total ),
 	$set_content_array = [
+		/* translators: %1$s is the count of payments, %2$s is the total amount. */
+		'payment-detail'   => sprintf( __( '%1$s payment of %2$s', 'installment-plans-for-woo-subs' ), $set_single_increm, $set_single_total ),
+		/* translators: %d is the total amount. */
 		'payment-counts'   => sprintf( _n( '%d total payment', '%d total payments', $set_single_count, 'installment-plans-for-woo-subs' ), $set_single_count ),
-		'payment-schedule' => sprintf( __( '%s per %s', 'installment-plans-for-woo-subs' ), $set_single_total, $subscription->get_billing_period() ),
+		/* translators: %1$s is the total, %2$s is the billing period. */
+		'payment-schedule' => sprintf( __( '%1$s per %2$s', 'installment-plans-for-woo-subs' ), $set_single_total, $subscription->get_billing_period() ),
+		/* translators: %s is the total amount. */
 		'payment-totals'   => sprintf( __( '%s total', 'installment-plans-for-woo-subs' ), $set_instalm_total ),
 		'no-remaining'     => esc_html_x( 'no remaining payments', 'the payment made was the final one', 'installment-plans-for-woo-subs' ),
 		'single-count'     => $set_single_count,

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -101,7 +101,7 @@ function wcsip_array_insert_after( $needle = '', $haystack = array(), $new_key =
 function wcsip_get_user_installments( $user_id = 0, $return_count = false ) {
 
 	// Make sure we have a user ID before we continue.
-	if ( 0 === $user_id || empty( $user_id ) ) {
+	if ( empty( $user_id ) ) {
 		$user_id = get_current_user_id();
 	}
 
@@ -138,5 +138,5 @@ function wcsip_get_user_installments( $user_id = 0, $return_count = false ) {
 	}
 
 	// Return the array or the count based on the request.
-	return false !== $return_count ? count( $subscriptions ) : $subscriptions;
+	return $return_count ? count( $subscriptions ) : $subscriptions;
 }

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -106,7 +106,7 @@ function wcsip_get_user_installments( $user_id = 0, $return_count = false ) {
 	}
 
 	// Attempt to fetch the IDs.
-	$fetch_sub_ids  = WCS_Customer_Store::instance()->get_users_subscription_ids( $user_id );
+	$fetch_sub_ids = WCS_Customer_Store::instance()->get_users_subscription_ids( $user_id );
 
 	// Bail without any IDs.
 	if ( empty( $fetch_sub_ids ) ) {
@@ -120,7 +120,7 @@ function wcsip_get_user_installments( $user_id = 0, $return_count = false ) {
 	foreach ( $fetch_sub_ids as $single_id ) {
 
 		// Attempt to get the subscription.
-		$subscription   = wcs_get_subscription( $single_id );
+		$subscription = wcs_get_subscription( $single_id );
 
 		// If we have one, add it to the array.
 		if ( false !== $subscription ) {

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -60,14 +60,8 @@ function wcsip_get_email_content_args( $subscription, $order ) {
  */
 function wcsip_array_insert_after( $needle = '', $haystack = array(), $new_key = '', $new_value ) {
 
-	// If any required parts are missing, or the
-	// haystack isn't an array, return the whole thing.
-	if ( empty( $needle ) || empty( $haystack ) || empty( $new_key ) || ! is_array( $haystack ) ) {
-		return $haystack;
-	}
-
-	// The array key didn't exist, so return the haystack.
-	if ( ! array_key_exists( $needle, $haystack ) ) {
+	// If any required parts are missing, or the haystack isn't an array, or the The array key does't exist, return the haystack.
+	if ( ! $needle || ! is_array( $haystack ) || empty( $haystack ) || ! array_key_exists( $needle, $haystack ) || ! $new_key ) {
 		return $haystack;
 	}
 
@@ -122,19 +116,10 @@ function wcsip_get_user_installments( $user_id = 0, $return_count = false ) {
 		// Attempt to get the subscription.
 		$subscription = wcs_get_subscription( $single_id );
 
-		// If we have one, add it to the array.
-		if ( false !== $subscription ) {
-
-			// Check for installments.
-			$maybe_has_installments = Helpers\maybe_order_has_installments( $subscription, false );
-
-			// If we have it, add it.
-			if ( false !== $maybe_has_installments ) {
-				$subscriptions[ $single_id ] = $subscription;
-			}
+		// If we have installments, add it.
+		if ( $subscription && Helpers\maybe_order_has_installments( $subscription, false ) ) {
+			$subscriptions[ $single_id ] = $subscription;
 		}
-
-		// Nothing left to loop inside the IDs.
 	}
 
 	// Return the array or the count based on the request.

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -58,7 +58,7 @@ function wcsip_get_email_content_args( $subscription, $order ) {
  *
  * @return array              The new array if the $needle key exists, otherwise an unmodified $haystack
  */
-function wcsip_array_insert_after( $needle = '', $haystack = array(), $new_key = '', $new_value ) {
+function wcsip_array_insert_after( $needle = '', $haystack = [], $new_key = '', $new_value = null ) {
 
 	// If any required parts are missing, or the haystack isn't an array, or the The array key does't exist, return the haystack.
 	if ( ! $needle || ! is_array( $haystack ) || empty( $haystack ) || ! array_key_exists( $needle, $haystack ) || ! $new_key ) {

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -25,9 +25,9 @@ function wcsip_get_email_content_args( $subscription, $order ) {
 	$get_single_count = get_post_meta( $order->get_id(), '_order_installment_count', true );
 
 	// Set our single total and increment.
-	$set_single_count   = ! empty( $get_single_count ) ? $get_single_count : 0;
 	$set_single_increm = Helpers\add_ordinal_suffix( $subscription->get_payment_count() );
 	$set_single_total  = wc_price( $subscription->get_total(), [ 'currency' => $subscription->get_currency() ] );
+	$set_single_count  = (int) $get_single_count;
 
 	// Calculate the total cost.
 	$calc_instalm_total = absint( $subscription->get_total() ) * absint( $set_single_count );

--- a/includes/woo/account.php
+++ b/includes/woo/account.php
@@ -200,14 +200,12 @@ function add_endpoint_content() {
 	// Return the WC template setup.
 	wc_get_template(
 		$set_template_args['name'],
-		array(
+		[
 			'installments'  => $get_installments,
 			'no_items_link' => $set_emptyitem_link,
 			'no_items_text' => $set_emptyitem_text,
-		),
+		],
 		'',
 		$set_template_args['path']
 	);
-
-	// Nothing left.
 }

--- a/includes/woo/account.php
+++ b/includes/woo/account.php
@@ -179,10 +179,10 @@ function change_single_view_title( $title, $endpoint, $action ) {
 function add_endpoint_content() {
 
 	// Get the installments.
-	$get_installments   = wcsip_get_user_installments();
+	$get_installments = wcsip_get_user_installments();
 
 	// Set our template name.
-	$set_template_name  = ! empty( $get_installments ) ? 'my-account/installments-list.php' : 'my-account/no-installments.php';
+	$set_template_name = ! empty( $get_installments ) ? 'my-account/installments-list.php' : 'my-account/no-installments.php';
 
 	// Set up our args in an array.
 	$set_template_args  = array(
@@ -191,7 +191,7 @@ function add_endpoint_content() {
 	);
 
 	// Run it through a filter for others to change.
-	$set_template_args  = apply_filters( Core\HOOK_PREFIX . 'endpoint_page_content_template_args', $set_template_args, $get_installments );
+	$set_template_args = apply_filters( Core\HOOK_PREFIX . 'endpoint_page_content_template_args', $set_template_args, $get_installments );
 
 	// Set the text for "no installment plans".
 	$set_emptyitem_link = apply_filters( Core\HOOK_PREFIX . 'no_installments_return_link', wc_get_page_permalink( 'shop' ) );

--- a/includes/woo/account.php
+++ b/includes/woo/account.php
@@ -22,7 +22,7 @@ add_filter( 'the_title', __NAMESPACE__ . '\change_endpoint_title', 11, 1 );
 add_filter( 'woocommerce_account_menu_items', __NAMESPACE__ . '\add_endpoint_menu_item' );
 add_filter( 'woocommerce_account_menu_item_classes', __NAMESPACE__ . '\maybe_add_active_class', 10, 2 );
 add_filter( 'woocommerce_endpoint_installment-plans_title', __NAMESPACE__ . '\change_list_view_title', 10, 3 );
-add_filter( 'woocommerce_endpoint_view-subscription_title', __NAMESPACE__ . '\change_single_view_title', 30, 3 );
+add_filter( 'woocommerce_endpoint_view-subscription_title', __NAMESPACE__ . '\change_single_view_title', 30 );
 add_action( 'woocommerce_account_installment-plans_endpoint', __NAMESPACE__ . '\add_endpoint_content' );
 
 /**
@@ -139,13 +139,11 @@ function change_list_view_title( $title, $endpoint, $action ) {
  *
  * We run this after Subscriptions does so we can change the ones that apply to us.
  *
- * @param  string $title     Default title.
- * @param  string $endpoint  Endpoint key.
- * @param  string $action    Optional action or variation within the endpoint.
+ * @param string $title Default title.
  *
  * @return string
  */
-function change_single_view_title( $title, $endpoint, $action ) {
+function change_single_view_title( $title ) {
 
 	// Call the global.
 	global $wp;

--- a/includes/woo/account.php
+++ b/includes/woo/account.php
@@ -58,7 +58,7 @@ function add_endpoint_menu_item( $menu_items ) {
 	}
 
 	// None existed, just throw it on the end.
-	return wp_parse_args( array( Core\FRONT_VAR => esc_attr( $menu_title ) ), $menu_items );
+	return wp_parse_args( [ Core\FRONT_VAR => esc_attr( $menu_title ) ], $menu_items );
 }
 
 /**
@@ -183,10 +183,10 @@ function add_endpoint_content() {
 	$set_template_name = ! empty( $get_installments ) ? 'my-account/installments-list.php' : 'my-account/no-installments.php';
 
 	// Set up our args in an array.
-	$set_template_args  = array(
+	$set_template_args = [
 		'name' => $set_template_name,
-		'path' => Core\TEMPLATES_PATH . '/'
-	);
+		'path' => Core\TEMPLATES_PATH . '/',
+	];
 
 	// Run it through a filter for others to change.
 	$set_template_args = apply_filters( Core\HOOK_PREFIX . 'endpoint_page_content_template_args', $set_template_args, $get_installments );

--- a/includes/woo/account.php
+++ b/includes/woo/account.php
@@ -171,8 +171,6 @@ function change_single_view_title( $title ) {
 
 /**
  * Add the content for our endpoint to display.
- *
- * @return HTML
  */
 function add_endpoint_content() {
 

--- a/includes/woo/admin.php
+++ b/includes/woo/admin.php
@@ -80,7 +80,7 @@ function render_installment_column_content( $column_name, $post_id ) {
 	}
 
 	// Check the meta.
-	$maybe_has  = get_post_meta( $post_id, '_order_has_installments', true );
+	$maybe_has = get_post_meta( $post_id, '_order_has_installments', true );
 
 	// Bail if we don't have a "yes".
 	if ( empty( $maybe_has ) || 'yes' !== sanitize_text_field( $maybe_has ) ) {

--- a/includes/woo/email.php
+++ b/includes/woo/email.php
@@ -46,7 +46,7 @@ function maybe_add_installment_info( $order, $is_admin_email, $plaintext = false
 	}
 
 	// Check for the existence of subscriptions.
-	$subscriptions  = wcs_get_subscriptions_for_order( $order, array( 'order_type' => 'any' ) );
+	$subscriptions = wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] );
 
 	// Bail if we don't have any subs at all.
 	if ( empty( $subscriptions ) ) {
@@ -54,7 +54,7 @@ function maybe_add_installment_info( $order, $is_admin_email, $plaintext = false
 	}
 
 	// Get our template args.
-	$template_args  = Helpers\get_order_email_template_args( $order->get_id(), $order, $plaintext );
+	$template_args = Helpers\get_order_email_template_args( $order->get_id(), $order, $plaintext );
 
 	// Bail if we somehow lost the args in the filter.
 	if ( empty( $template_args ) ) {

--- a/includes/woo/email.php
+++ b/includes/woo/email.php
@@ -64,11 +64,11 @@ function maybe_add_installment_info( $order, $is_admin_email, $plaintext = false
 	// Return the WC template setup.
 	wc_get_template(
 		$template_args['file'],
-		array(
+		[
 			'order'          => $order,
 			'subscriptions'  => $subscriptions,
 			'is_admin_email' => $is_admin_email,
-		),
+		],
 		'',
 		$template_args['base']
 	);

--- a/includes/woo/email.php
+++ b/includes/woo/email.php
@@ -25,7 +25,7 @@ add_action( 'woocommerce_email_after_order_table', __NAMESPACE__ . '\maybe_add_i
  * @return void
  */
 function remove_subscription_box() {
-	remove_action( 'woocommerce_email_after_order_table', 'WC_Subscriptions_Order::add_sub_info_email', 15, 3 );
+	remove_action( 'woocommerce_email_after_order_table', 'WC_Subscriptions_Order::add_sub_info_email', 15 );
 }
 
 /**

--- a/includes/woo/meta.php
+++ b/includes/woo/meta.php
@@ -33,13 +33,13 @@ function add_installment_option_type( $product_types ) {
 	if ( ! isset( $product_types['is_installments'] ) ) {
 
 		// Add our new one.
-		$product_types['is_installments'] = array(
+		$product_types['is_installments'] = [
 			'id'            => '_is_installments',
 			'wrapper_class' => 'show_if_subscription show_if_variable-subscription',
 			'label'         => __( 'Installments', 'installment-plans-for-woo-subs' ),
 			'description'   => __( 'This subscription will be used for installment payments.', 'installment-plans-for-woo-subs' ),
 			'default'       => 'no',
-		);
+		];
 	}
 
 	// And return the updated array.

--- a/includes/woo/meta.php
+++ b/includes/woo/meta.php
@@ -56,7 +56,7 @@ function add_installment_option_type( $product_types ) {
 function save_installment_option_type( $product_id ) {
 
 	// Check for the POST value.
-	$is_installment = isset( $_POST['_is_installments'] ) ? 'yes' : 'no';
+	$is_installment = isset( $_POST['_is_installments'] ) ? 'yes' : 'no'; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 	// Set the meta key.
 	update_post_meta( $product_id, '_is_installments', $is_installment );

--- a/includes/woo/orders.php
+++ b/includes/woo/orders.php
@@ -16,17 +16,14 @@ use Nexcess\InstallmentPlansWooSubs\Utilities as Utilities;
 /**
  * Start our engines.
  */
-add_action( 'woocommerce_checkout_create_order', __NAMESPACE__ . '\save_installment_order_meta', 20, 2 );
+add_action( 'woocommerce_checkout_create_order', __NAMESPACE__ . '\save_installment_order_meta', 20, 1 );
 
 /**
  * Add to the order meta if someone purchased an installment.
  *
- * @param  object $order  The WooCommerce order object.
- * @param  array  $data   The data being passed to make the order.
- *
- * @return void
+ * @param \WC_Order $order The WooCommerce order object.
  */
-function save_installment_order_meta( $order, $data ) {
+function save_installment_order_meta( $order ) {
 
 	// Check for the installments.
 	$maybe_has_installments = Helpers\maybe_order_has_installments( $order );

--- a/includes/woo/query-mods.php
+++ b/includes/woo/query-mods.php
@@ -80,7 +80,7 @@ function add_installments_endpoint_vars( $vars ) {
  * @since  2.3.0
  */
 function add_woo_query_vars( $query_vars ) {
-	return array_merge( $query_vars, array( Core\FRONT_VAR => Core\FRONT_VAR ) );
+	return array_merge( $query_vars, [ Core\FRONT_VAR => Core\FRONT_VAR ] );
 }
 
 /**
@@ -157,7 +157,7 @@ function modify_installment_product_queries( $query_vars ) {
 	// and put the product type back to subscriptions.
 	$query_vars['meta_value']   = 'yes';
 	$query_vars['meta_key']     = '_is_installments';
-	$query_vars['product_type'] = array( 'subscription', 'variable-subscription' );
+	$query_vars['product_type'] = [ 'subscription', 'variable-subscription' ];
 
 	// And return the updated vars.
 	return $query_vars;

--- a/includes/woo/query-mods.php
+++ b/includes/woo/query-mods.php
@@ -146,7 +146,7 @@ function modify_installment_product_queries( $query_vars ) {
 	}
 
 	// Make sure we have a product type to check against.
-	$current_product_type = isset( $_REQUEST['product_type'] ) ? wc_clean( wp_unslash( $_REQUEST['product_type'] ) ) : false;
+	$current_product_type = isset( $_REQUEST['product_type'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['product_type'] ) ) : false; // phpcs:disable WordPress.Security.NonceVerification.Recommended
 
 	// Bail if we didn't request installments.
 	if ( 'installments' !== $current_product_type ) {
@@ -181,7 +181,7 @@ function modify_installment_order_queries( $query_vars ) {
 	}
 
 	// Make sure we have a product type to check against.
-	$maybe_sub_type = isset( $_GET['shop_order_subtype'] ) ? wc_clean( wp_unslash( $_GET['shop_order_subtype'] ) ) : false;
+	$maybe_sub_type = isset( $_GET['shop_order_subtype'] ) ? sanitize_text_field( wp_unslash( $_GET['shop_order_subtype'] ) ) : false; // phpcs:disable WordPress.Security.NonceVerification.Recommended
 
 	// Bail if we didn't request installments.
 	if ( 'installments' !== $maybe_sub_type ) {

--- a/includes/woo/query-mods.php
+++ b/includes/woo/query-mods.php
@@ -35,7 +35,7 @@ function maybe_finish_installments_setup() {
 	$has_completed  = get_option( Core\OPTION_PREFIX . 'activation_complete', false );
 
 	// It's there and flagged as "yes", so we're done.
-	if ( ! empty( $has_completed ) && 'yes' === sanitize_text_field( $has_completed ) ) {
+	if ( 'yes' === sanitize_text_field( $has_completed ) ) {
 		return;
 	}
 
@@ -149,7 +149,7 @@ function modify_installment_product_queries( $query_vars ) {
 	$current_product_type = isset( $_REQUEST['product_type'] ) ? wc_clean( wp_unslash( $_REQUEST['product_type'] ) ) : false;
 
 	// Bail if we didn't request installments.
-	if ( ! $current_product_type || 'installments' !== $current_product_type ) {
+	if ( 'installments' !== $current_product_type ) {
 		return $query_vars;
 	}
 
@@ -184,7 +184,7 @@ function modify_installment_order_queries( $query_vars ) {
 	$maybe_sub_type = isset( $_GET['shop_order_subtype'] ) ? wc_clean( wp_unslash( $_GET['shop_order_subtype'] ) ) : false;
 
 	// Bail if we didn't request installments.
-	if ( ! $maybe_sub_type || 'installments' !== $maybe_sub_type ) {
+	if ( 'installments' !== $maybe_sub_type ) {
 		return $query_vars;
 	}
 

--- a/includes/woo/query-mods.php
+++ b/includes/woo/query-mods.php
@@ -20,7 +20,7 @@ add_action( 'init', __NAMESPACE__ . '\maybe_finish_installments_setup' );
 add_action( 'init', __NAMESPACE__ . '\add_installments_rewrite_endpoint' );
 add_filter( 'query_vars', __NAMESPACE__ . '\add_installments_endpoint_vars', 0 );
 add_filter( 'woocommerce_get_query_vars', __NAMESPACE__ . '\add_woo_query_vars' );
-add_filter( 'wcs_get_users_subscriptions', __NAMESPACE__ . '\remove_installments_from_list', 20, 2 );
+add_filter( 'wcs_get_users_subscriptions', __NAMESPACE__ . '\remove_installments_from_list', 20, 1 );
 add_filter( 'request', __NAMESPACE__ . '\modify_installment_product_queries', 21 );
 add_filter( 'request', __NAMESPACE__ . '\modify_installment_order_queries', 21 );
 
@@ -86,12 +86,11 @@ function add_woo_query_vars( $query_vars ) {
 /**
  * Remove installment items from the main subscriptions list.
  *
- * @param  array   $subscriptions  The existing subscriptions.
- * @param  integer $user_id        The user being listed.
+ * @param array $subscriptions The existing subscriptions.
  *
- * @return array                   The potentially modified array.
+ * @return array The potentially modified array.
  */
-function remove_installments_from_list( $subscriptions, $user_id ) {
+function remove_installments_from_list( $subscriptions ) {
 
 	// Immediately bail if this is on the admin side
 	// or isn't on the actual account page.

--- a/includes/woo/query-mods.php
+++ b/includes/woo/query-mods.php
@@ -32,7 +32,7 @@ add_filter( 'request', __NAMESPACE__ . '\modify_installment_order_queries', 21 )
 function maybe_finish_installments_setup() {
 
 	// Grab our option flag.
-	$has_completed  = get_option( Core\OPTION_PREFIX . 'activation_complete', false );
+	$has_completed = get_option( Core\OPTION_PREFIX . 'activation_complete', false );
 
 	// It's there and flagged as "yes", so we're done.
 	if ( 'yes' === sanitize_text_field( $has_completed ) ) {

--- a/includes/woo/query-mods.php
+++ b/includes/woo/query-mods.php
@@ -100,28 +100,17 @@ function remove_installments_from_list( $subscriptions, $user_id ) {
 	}
 
 	// Allow this filter to be disabled.
-	if ( false !== apply_filters( Core\HOOK_PREFIX . 'disable_subscriptions_list_filter', false ) ) {
-		return $subscriptions;
-	}
-
-	// Return the empty array if that is what we were provided.
-	if ( empty( $subscriptions ) ) {
+	if ( apply_filters( Core\HOOK_PREFIX . 'disable_subscriptions_list_filter', false ) ) {
 		return $subscriptions;
 	}
 
 	// Now loop and check our meta key.
 	foreach ( $subscriptions as $subscription_id => $subscription_obj ) {
 
-		// Check the meta.
-		$maybe_has  = get_post_meta( $subscription_id, '_order_has_installments', true );
-
-		// Skip if it isn't in the array.
-		if ( empty( $maybe_has ) || 'yes' !== sanitize_text_field( $maybe_has ) ) {
-			continue;
-		}
-
 		// Remove this one from the overall array.
-		unset( $subscriptions[ $subscription_id ] );
+		if ( 'yes' === sanitize_text_field( get_post_meta( $subscription_id, '_order_has_installments', true ) ) ) {
+			unset( $subscriptions[ $subscription_id ] );
+		}
 	}
 
 	// And return this.

--- a/installment-plans-for-woo-subs.php
+++ b/installment-plans-for-woo-subs.php
@@ -47,15 +47,12 @@ define( __NAMESPACE__ . '\TRANSIENT_PREFIX', 'wcsip_tr_' );
 define( __NAMESPACE__ . '\FRONT_VAR', 'installment-plans' );
 
 // Now we handle all the various file loading.
-nx_wcs_installment_plans_file_load();
+add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_files' );
 
 /**
  * Actually load our files.
- *
- * @return void
  */
-function nx_wcs_installment_plans_file_load() {
-
+function load_files() {
 	// Load the multi-use files first.
 	require_once __DIR__ . '/includes/helpers.php';
 	require_once __DIR__ . '/includes/utilities.php';


### PR DESCRIPTION
- Don't use prefixed function when we're namespaced
- Move activation/deactivation hook registration to top of file
- Use sanitize_text_field directly instead of the wc wrapper
- Fix spacing
- Simplify active check
- Improve wpdb calls
- Remove unneeded params
- Switch to short arrays
- Strict in_array check
- Update some more docblocks
- Simplify checks
- Add translator comments
